### PR TITLE
Cerca per capes

### DIFF
--- a/Programes especifics/MaBIM/qMaBIM.py
+++ b/Programes especifics/MaBIM/qMaBIM.py
@@ -355,37 +355,37 @@ class Cercador:
     def __init__(self, canvas, leCarrer, leNumero, lblIcona):
         super().__init__()
         self.canvas = canvas
-        self.marcaLloc = None
+        self.marca_geometria = None
         self.leCarrer = leCarrer
         self.leCarrer.setPlaceholderText('Carrer')
         self.leNumero = leNumero
         self.leNumero.setPlaceholderText('Número')
         self.lblIcona = lblIcona
         self.cercador = QCercadorAdreca(self.leCarrer, self.leNumero, 'SQLITE')
-        self.marcaLlocPosada = False
+        self.marcaLlocGeometria = False
 
-        self.cercador.sHanTrobatCoordenades.connect(self.resultatCercador)
+        self.cercador.coordenades_trobades.connect(self.resultatCercador)
 
     def resultatCercador(self, codi, info):
         if codi == 0:
             self.canvas.setCenter(self.cercador.coordAdreca)
             self.canvas.zoomScale(1000)
-            self.canvas.scene().removeItem(self.marcaLloc)
+            self.canvas.scene().removeItem(self.marca_geometria)
 
-            self.marcaLloc = QgsVertexMarker(self.canvas)
-            self.marcaLloc.setCenter( self.cercador.coordAdreca )
-            self.marcaLloc.setColor(QtGui.QColor(255, 0, 0))
-            self.marcaLloc.setIconSize(15)
-            self.marcaLloc.setIconType(QgsVertexMarker.ICON_BOX)
-            self.marcaLloc.setPenWidth(3)
-            self.marcaLloc.show()
-            self.marcaLlocPosada = True
+            self.marca_geometria = QgsVertexMarker(self.canvas)
+            self.marca_geometria.setCenter( self.cercador.coordAdreca )
+            self.marca_geometria.setColor(QtGui.QColor(255, 0, 0))
+            self.marca_geometria.setIconSize(15)
+            self.marca_geometria.setIconType(QgsVertexMarker.ICON_BOX)
+            self.marca_geometria.setPenWidth(3)
+            self.marca_geometria.show()
+            self.marcaLlocGeometria = True
             self.leCarrer.clear()
             self.leNumero.clear()
     def eliminaMarcaLloc(self):
-        if self.marcaLlocPosada:
-            self.canvas.scene().removeItem(self.marcaLloc)
-            self.marcaLlocPosada = False
+        if self.marcaLlocGeometria:
+            self.canvas.scene().removeItem(self.marca_geometria)
+            self.marcaLlocGeometria = False
 
 class FavoritsMaBIM(QvFavorits):
     dadesDB = ConstantsMaBIM.DB_MABIM_PRO
@@ -753,7 +753,7 @@ class QMaBIM(QtWidgets.QMainWindow):
         self.mapetaA.setStyleSheet('''QMenu{background-color: #DDDDDD;color: #38474F;}QMenu::item:selected{background-color: #FF6215;color: #F9F9F9;}''')
 
         self.cerca1 = Cercador(self.canvasA, self.leCarrer, self.leNumero, self.lblIcona)
-        self.cerca1.cercador.sHanTrobatCoordenades.connect(lambda: self.tabCentral.setCurrentIndex(2))
+        self.cerca1.cercador.coordenades_trobades.connect(lambda: self.tabCentral.setCurrentIndex(2))
 
         botoSelecciona = self.canvasA.afegirBotoCustom('botoSelecciona', 'imatges/apuntar.png', 'Selecciona BIM gràficament', 1)
         def setEinaSeleccionar():

--- a/Programes especifics/MaBIM/qMaBIM.py
+++ b/Programes especifics/MaBIM/qMaBIM.py
@@ -6,7 +6,6 @@ import math
 import os
 import subprocess
 import sys
-import datetime
 from pathlib import Path
 from typing import Sequence
 
@@ -502,9 +501,6 @@ class QMaBIM(QtWidgets.QMainWindow):
         res1 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt1})[0][0].toString(QtCore.Qt.ISODate)
         res2 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt2})[0][0].toString(QtCore.Qt.ISODate)
         res3 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt3})[0][0].toString(QtCore.Qt.ISODate)
-        # res1 = str(datetime.datetime.now())
-        # res2 = str(datetime.datetime.now())
-        # res3 = str(datetime.datetime.now())
 
         font = QtGui.QFont()
         font.setFamily("Segoe UI Light")

--- a/Programes especifics/MaBIM/qMaBIM.py
+++ b/Programes especifics/MaBIM/qMaBIM.py
@@ -6,6 +6,7 @@ import math
 import os
 import subprocess
 import sys
+import datetime
 from pathlib import Path
 from typing import Sequence
 
@@ -361,7 +362,7 @@ class Cercador:
         self.leNumero = leNumero
         self.leNumero.setPlaceholderText('Número')
         self.lblIcona = lblIcona
-        self.cercador = QCercadorAdreca(self.leCarrer, self.leNumero, 'SQLITE')
+        self.cercador = QCercadorAdreca(self.leCarrer, 'SQLITE', self.leNumero)
         self.marcaLlocGeometria = False
 
         self.cercador.coordenades_trobades.connect(self.resultatCercador)
@@ -501,6 +502,10 @@ class QMaBIM(QtWidgets.QMainWindow):
         res1 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt1})[0][0].toString(QtCore.Qt.ISODate)
         res2 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt2})[0][0].toString(QtCore.Qt.ISODate)
         res3 = cons.consulta(ConstantsMaBIM.CONSULTA_DATA_DADES,{':pText':txt3})[0][0].toString(QtCore.Qt.ISODate)
+        # res1 = str(datetime.datetime.now())
+        # res2 = str(datetime.datetime.now())
+        # res3 = str(datetime.datetime.now())
+
         font = QtGui.QFont()
         font.setFamily("Segoe UI Light")
         font.setPointSize(5)

--- a/moduls/QVCercadorAdreca.py
+++ b/moduls/QVCercadorAdreca.py
@@ -281,9 +281,10 @@ class QCercadorAdreca(QObject):
         """
         for layer_id in layer_ids:
             obtenir_capes = self.obtenir_variables_qvSearch(layer_id)
-            for capa in obtenir_capes:
-                self.afegir_cerca(layer_id.id(),capa[0],capa[1])
-                self.combo_tipus_cerca.addItem(capa[1])
+            if obtenir_capes:
+                for field, desc in obtenir_capes:
+                    self.afegir_cerca(layer_id.id(),field,desc)
+                    self.combo_tipus_cerca.addItem(desc)
         self.carregar_elements_capes()
 
     def connect_layers_removed(self):

--- a/moduls/QVCercadorAdreca.py
+++ b/moduls/QVCercadorAdreca.py
@@ -236,6 +236,7 @@ class QCercadorAdreca(QObject):
                 print("Error")
         
         self.leNumero.returnPressed.connect(self.trobatCantonada)
+        self.leNumero.returnPressed.connect(self.trobatNumero)
         self.leCarrer.textChanged.connect(lambda: self.habilitaLeNum(self.leCarrer.text()))
 
         self.carrerActivat = False

--- a/moduls/QVCercadorAdreca.py
+++ b/moduls/QVCercadorAdreca.py
@@ -284,6 +284,7 @@ class QCercadorAdreca(QObject):
             for capa in obtenir_capes:
                 self.afegir_cerca(layer_id.id(),capa[0],capa[1])
                 self.combo_tipus_cerca.addItem(capa[1])
+        self.carregar_elements_capes()
 
     def connect_layers_removed(self):
         """
@@ -442,13 +443,13 @@ class QCercadorAdreca(QObject):
         També manté un comptador de la posició que s'incrementa amb cada iteració.
         """
         posicio = 1
-        for element in self.llistaCerques:
-            capa = QgsProject.instance().mapLayers().get(element['layer'])
+        for variable in self.llistaCerques:
+            capa = QgsProject.instance().mapLayers().get(variable['layer'])
             if not capa:
                 return
 
             dict_capa_local = {}
-            element_cerca = element['field']
+            element_cerca = variable['field']
             for element in capa.getFeatures():
                 id_element = str(element.id())
                 atribut_element = element.attribute(element_cerca)
@@ -770,7 +771,7 @@ class QCercadorAdreca(QObject):
             bool: Retorna True si l'element està en `dictCapa` i s'ha activat correctament, False altrament.
         """
         self.carrerActivat = True
-        if element in self.dictCapa:
+        if element in self.dictCapaInvers:
             self.leCarrer.setAlignment(Qt.AlignLeft)
             self.leCarrer.setText(element)
             self.iniAdreca()

--- a/moduls/QVCercadorAdreca.py
+++ b/moduls/QVCercadorAdreca.py
@@ -263,6 +263,11 @@ class QCercadorAdreca(QObject):
     def set_projecte(self,project):
         self.project = project
 
+    def reset_cerca(self):
+        self.llistaCerques = []
+        self.combo_tipus_cerca.clear()
+        self.combo_tipus_cerca.addItems([TipusCerca.ADRECAPOSTAL.value, TipusCerca.CRUILLA.value])
+
 
     def afegir_cerca(self, layer_name:str, field_name:str, desc_value:str) -> None:
         """
@@ -274,7 +279,6 @@ class QCercadorAdreca(QObject):
             'desc': desc_value
         }
         self.llistaCerques.append(values_dict)
-        self.combo_tipus_cerca.addItem(desc_value)
 
     def obtenir_variables_cerca(self) -> List[str]:
         """
@@ -308,6 +312,7 @@ class QCercadorAdreca(QObject):
                 if layers:
                     layer_id = layers[0].id()
                     self.afegir_cerca(layer_id, field_match.group(1), desc_match.group(1))
+                    self.combo_tipus_cerca.addItem(desc_match.group(1))
                     self.obtenirVariablesQVSearch(layer_id)
                 else:
                     print(f"No existeix la capa {layer_name}")
@@ -345,12 +350,15 @@ class QCercadorAdreca(QObject):
                 desc_match = desc_regex.search(valor_variable)
 
                 if id_capa and field_match and desc_match:
-                    self.afegir_cerca(capa.name(), field_match.group(1), desc_match.group(1))
+                    self.afegir_cerca(id_capa, field_match.group(1), desc_match.group(1))
+                    self.combo_tipus_cerca.addItem(desc_match.group(1))
+
 
     def carregarTipusCerques(self) -> None:
         """
         Aquesta funció carrega els tipus de cerques disponibles a partir de les variables del projecte que comencen amb un prefix específic.
         """
+        self.reset_cerca()
         self.processar_variables_cerca()
         self.carregar_totes_capes()
         self.carregar_elements_capes()

--- a/moduls/QVCercadorAdreca.py
+++ b/moduls/QVCercadorAdreca.py
@@ -216,8 +216,8 @@ class ValidadorNums(QValidator):
 
 
 class QCercadorAdreca(QObject):
-    coordenades_trobades = pyqtSignal(int, 'QString') #canviar a coordenades_trobades
-    area_trobada = pyqtSignal(int, 'QString') #canviat a area_trobada
+    coordenades_trobades = pyqtSignal(int, 'QString')
+    area_trobada = pyqtSignal(int, 'QString')
     punt_trobat = pyqtSignal(int, 'QString')
 
     def __init__(self, lineEditCarrer, origen='SQLITE', lineEditNumero=None, project=None, comboTipusCerca=None):
@@ -235,25 +235,16 @@ class QCercadorAdreca(QObject):
             except ValueError as e:
                 print("Error")
         
-        
-        
-
-        
         self.leNumero.returnPressed.connect(self.trobatCantonada)
         self.leCarrer.textChanged.connect(lambda: self.habilitaLeNum(self.leCarrer.text()))
 
-        self.llistaCerques = []
-
-
         self.carrerActivat = False
-
+        self.llistaCerques = []
         self.dictCarrers = {}
         self.dictNumeros = collections.defaultdict(dict)
         self.dictCantonades = collections.defaultdict(dict)
         self.dictCapa = collections.defaultdict(dict)
         self.dictCapes = collections.defaultdict(dict)
-
-        # self.carregarTipusCerques()
 
         self.numClick=0
         self.db = QvApp().dbGeo
@@ -300,7 +291,7 @@ class QCercadorAdreca(QObject):
                 layer_name = layer_match.group(1)
                 layers = QgsProject.instance().mapLayersByName(layer_name)
                 if layers:
-                    layer_id = layers[0].id()  # Agafem l'ID de la primera capa trobada
+                    layer_id = layers[0].id()
                     desc_value = desc_match.group(1)
                     values_dict = {
                         'layer': layer_name,
@@ -310,7 +301,7 @@ class QCercadorAdreca(QObject):
 
                     self.llistaCerques.append(values_dict)
                     self.combo_tipus_cerca.addItem(desc_value)
-                    self.obtenirVariablesQVSearch(layer_id)  # Passem l'ID de la capa
+                    self.obtenirVariablesQVSearch(layer_id)
                 else:
                     print(f"No existeix la capa {layer_name}")
 
@@ -350,7 +341,6 @@ class QCercadorAdreca(QObject):
     def habilitaLeNum(self, valorAntic):
         self.carrerActivat = False
         condicio_per_habilitar = valorAntic in self.dictCarrers
-        # condicio_per_habilitar = (self.txto != '' or self.calle_con_acentos != '' or self.leCarrer.text().strip() != '')
         self.leNumero.setEnabled(condicio_per_habilitar)
 
     def cercadorAdrecaFi(self):
@@ -618,10 +608,10 @@ class QCercadorAdreca(QObject):
 
         while self.query.next():
             row = collections.OrderedDict()
-            row['NUM_LLETRA_POST'] = self.query.value(1)  # Numero y Letra
-            row['ETRS89_COORD_X'] = self.query.value(2)  # coor x
-            row['ETRS89_COORD_Y'] = self.query.value(3)  # coor y
-            row['NUM_OFICIAL'] = self.query.value(4)  # numero oficial
+            row['NUM_LLETRA_POST'] = self.query.value(1)
+            row['ETRS89_COORD_X'] = self.query.value(2)
+            row['ETRS89_COORD_Y'] = self.query.value(3)
+            row['NUM_OFICIAL'] = self.query.value(4)
 
             self.dictNumeros[self.codiCarrer][self.query.value(1)] = row
 
@@ -753,7 +743,7 @@ class QCercadorAdreca(QObject):
 
         else:
             info = "L'adreça és buida. Codi d'error 1"
-            self.coordenades_trobades.emit(1, info)  # adreça vacia
+            self.coordenades_trobades.emit(1, info)
         self.habilitaLeNum(carrerAntic)
         self.focusANumero()
 
@@ -787,12 +777,10 @@ class QCercadorAdreca(QObject):
             self.leNumero.setCompleter(None)
             return
         if not self.carrerActivat:
-            # així obtenim el carrer on estàvem encara que no l'haguem seleccionat explícitament
             self.txto = self.completerCarrer.popup().currentIndex().data()
             txtoAntic = self.txto
             if self.txto is None:
                 return
-                # self.txto = self.completerCarrer.currentCompletion()
             if self.txto == '':
                 return
 
@@ -828,15 +816,14 @@ class QCercadorAdreca(QObject):
 
                 else:
                     info = "La direcció no és al diccionari. Codi d'error 2"
-                    # direccion no está en diccicionario
                     self.coordenades_trobades.emit(2, info)
                     self.iniAdreca()
             else:
                 info = "Codi d'error 3"
-                self.coordenades_trobades.emit(3, info)  # nunca
+                self.coordenades_trobades.emit(3, info)
         else:
             info = "L'adreça és buida. Codi d'error 1"
-            self.coordenades_trobades.emit(1, info)  # adreça vac
+            self.coordenades_trobades.emit(1, info)
         
         self.habilitaLeNum(txtoAntic)
 
@@ -868,8 +855,6 @@ class QCercadorAdreca(QObject):
         self.leNumero.clearFocus()
         self.coordenades_trobades.emit(0, "[0]")
 
-        # if self.leNumero.text() == ' ':
-        #     self.leNumero.clear()
         self.leNumero.clear()
 
     def comprovarCantonadesCarrer(self, cantonada: str) -> None:
@@ -942,9 +927,9 @@ class QCercadorAdreca(QObject):
                 "select codi , nom_oficial , variants  from Carrers")
 
             while self.query.next():
-                codi_carrer = self.query.value(0)  # Codigo calle
-                nombre = self.query.value(1)  # numero oficial
-                variants = self.query.value(2).lower()  # Variants del nom
+                codi_carrer = self.query.value(0)
+                nombre = self.query.value(1)
+                variants = self.query.value(2).lower()
                 nombre_sin_acentos = self.remove_accents(nombre)
                 if nombre == nombre_sin_acentos:
                     clave = nombre + \
@@ -979,7 +964,6 @@ class QCercadorAdreca(QObject):
         self.txto = self.completerCarrer.popup().currentIndex().data()
         if self.txto is None:
             self.txto = ''
-            # self.txto = self.completerCarrer.currentCompletion()
         else:
             self.txto=self.txto.replace('(var) ','')
         if self.txto in self.dictCarrers:
@@ -996,18 +980,15 @@ class QCercadorAdreca(QObject):
                 info = "[0]"
                 self.coordenades_trobades.emit(0, info)
                 self.leNumero.clear()
-                # if self.leNumero.text() == ' ':
-                #     self.leNumero.clear()
 
         else:
             info = "El número és buit. Codi d'error 4"
-            self.coordenades_trobades.emit(4, info)  # numero
+            self.coordenades_trobades.emit(4, info)
 
     def trobatNumero(self):
         if self.get_tipus_cerca() != TipusCerca.ADRECAPOSTAL.value: 
             return None
         
-        # Si no hi ha carrer, eliminem el completer del número
         if self.leCarrer.text() == '':
             self.leNumero.setCompleter(None)
         if self.leNumero.text() == '':
@@ -1016,7 +997,6 @@ class QCercadorAdreca(QObject):
             self.txto = self.completerCarrer.popup().currentIndex().data()
             if self.txto is None:
                 self.txto = ''
-                # self.txto = self.completerCarrer.currentCompletion()
             else:
                 self.txto=self.txto.replace('(var) ','')
             if self.txto in self.dictCarrers:
@@ -1043,24 +1023,21 @@ class QCercadorAdreca(QObject):
                             info = "[0]"
                             self.coordenades_trobades.emit(0, info)
                             self.leNumero.clear()
-                            # if self.leNumero.text() == ' ':
-                            #     self.leNumero.clear()
 
                         else:
                             info = "El número no és al diccionari. Codi d'error 5"
-                            # numero no está en diccicionario
                             self.coordenades_trobades.emit(5, info)
                     else:
                         info = "El número és buit. Codi d'error 4"
                         self.coordenades_trobades.emit(
-                            4, info)  # adreça vacia  nunca
+                            4, info)
                 else:
                     info = "El número està en blanc. Codi d'error 6"
-                    self.coordenades_trobades.emit(6, info)  # numero en blanco
+                    self.coordenades_trobades.emit(6, info)
             else:
                 self.leNumero.clear()
                 info = "El número és en blanc. Codi d'error 6"
-                self.coordenades_trobades.emit(6, info)  # numero en blanco
+                self.coordenades_trobades.emit(6, info)
         except:
             mostrar_error(info)
 

--- a/moduls/QvLlegenda.py
+++ b/moduls/QvLlegenda.py
@@ -222,8 +222,11 @@ class QvLlegenda(qgGui.QgsLayerTreeView):
         return msg
     
 
-    # Función estandar para leer proyecto dentro de qVista
+    # 
     def readProject(self, fileName):
+        """
+        Lee proyecto dentro de qVista
+        """
         self.recarrega.resetTimers()
         if self.anotacions is not None:
             self.anotacions.removeAnnotations()

--- a/moduls/QvUbicacions.py
+++ b/moduls/QvUbicacions.py
@@ -400,15 +400,15 @@ class QvUbicacions(QWidget):
             if self.model.itemFromIndex(self.arbre.currentIndex().sibling(self.arbre.currentIndex().row(), 0)).text()[0] == chr(45): # "-" :
                 if self.model.itemFromIndex(self.arbre.currentIndex().sibling(self.arbre.currentIndex().row(), 0)).text()[1] ==chr(62): #">" :
 
-                    self.canvas.scene().removeItem(self.pare.marcaLloc)
-                    self.pare.marcaLloc = QgsVertexMarker(self.pare.canvas)
-                    self.pare.marcaLloc.setCenter( QgsPointXY(float((xxmin+xxmax)/2),  float((yymin+yymax)/2)) )
-                    self.pare.marcaLloc.setColor(QColor(255, 0, 0))
-                    self.pare.marcaLloc.setIconSize(15)
-                    self.pare.marcaLloc.setIconType(QgsVertexMarker.ICON_CIRCLE) # or  ICON_NONE, ICON_CROSS, ICON_X, ICON_BOX, ICON_CIRCLE, ICON_DOUBLE_TRIANGLE 
-                    self.pare.marcaLloc.setPenWidth(3)
-                    self.pare.marcaLloc.show()
-                    self.pare.marcaLlocPosada = True
+                    self.canvas.scene().removeItem(self.pare.marca_geometria)
+                    self.pare.marca_geometria = QgsVertexMarker(self.pare.canvas)
+                    self.pare.marca_geometria.setCenter( QgsPointXY(float((xxmin+xxmax)/2),  float((yymin+yymax)/2)) )
+                    self.pare.marca_geometria.setColor(QColor(255, 0, 0))
+                    self.pare.marca_geometria.setIconSize(15)
+                    self.pare.marca_geometria.setIconType(QgsVertexMarker.ICON_CIRCLE) # or  ICON_NONE, ICON_CROSS, ICON_X, ICON_BOX, ICON_CIRCLE, ICON_DOUBLE_TRIANGLE 
+                    self.pare.marca_geometria.setPenWidth(3)
+                    self.pare.marca_geometria.show()
+                    self.pare.marcaLlocGeometria = True
         except :
             pass
         

--- a/moduls/constants.py
+++ b/moduls/constants.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class Resultat(Enum):
+    CORRECTE=0
+    ADRECA_BUIDA=1
+    DIRECCIO_NO_AL_DICCIONARI=2
+    ADRECA_NO_COINCIDENT=3
+    NUMERO_BUIT=4
+    NUMERO_NO_AL_DICCIONARI=5
+    NUMERO_BLANC=6
+    NUMERO_NO_COINCIDENT=7
+
+class TipusCerca(Enum):
+    ADRECAPOSTAL = "Adreça Postal"
+    CRUILLA = "Cruïlla"

--- a/moduls/eines/EinaMultiruta.py
+++ b/moduls/eines/EinaMultiruta.py
@@ -303,7 +303,7 @@ class PointUI_element:
         self.layoutPunt.addWidget(self.buttonRemovePoint)
 
         self.cercador = QCercadorAdreca(self.LECarrer, self.LENumero,'SQLITE')
-        self.cercador.sHanTrobatCoordenades.connect(lambda:eina.APostaltoCoord(self.pointNumber))
+        self.cercador.coordenades_trobades.connect(lambda:eina.APostaltoCoord(self.pointNumber))
 
 class PointTool(QgsMapTool):  
         def __init__(self, canvas, parent):

--- a/moduls/eines/EinaRuta.py
+++ b/moduls/eines/EinaRuta.py
@@ -284,7 +284,7 @@ class EinaRuta(QWidget):
 
                     # Activem la clase de cerca d'adreces
                     self.cercadorInici = QCercadorAdreca(self.IniciLECarrer, self.IniciLENumero,'SQLITE')
-                    self.cercadorInici.sHanTrobatCoordenades.connect(self.APostaltoCoord_Inici)
+                    self.cercadorInici.coordenades_trobades.connect(self.APostaltoCoord_Inici)
 
                 def preparacioCercadorEndPoint(lay):
                     #layout vertical per posar títol
@@ -325,7 +325,7 @@ class EinaRuta(QWidget):
 
                     # Activem la clase de cerca d'adreces
                     self.cercadorFinal = QCercadorAdreca(self.FiLECarrer, self.FiLENumero,'SQLITE')
-                    self.cercadorFinal.sHanTrobatCoordenades.connect(self.APostaltoCoord_Final)
+                    self.cercadorFinal.coordenades_trobades.connect(self.APostaltoCoord_Final)
                 
                 def preparacioBotoInvertirRuta(lay):
                     layoutRevertir = QHBoxLayout()

--- a/qVista.py
+++ b/qVista.py
@@ -1379,6 +1379,8 @@ class QVista(QMainWindow, Ui_MainWindow):
         else:
             self.leNumCerca.show()
             self.leCercaPerAdreca.setPlaceholderText('Carrer, plaça...')
+            if tipus_seleccionat == TipusCerca.CRUILLA.value:
+                self.leNumCerca.setPlaceholderText('Carrer, plaça...')
         
 
     def definicioBotons(self):

--- a/qVista.py
+++ b/qVista.py
@@ -1370,17 +1370,18 @@ class QVista(QMainWindow, Ui_MainWindow):
             index (int): Índex de la selecció actual del QComboBox comboTipusCerca
         """
         tipus_seleccionat = self.comboTipusCerca.itemText(index)
-        self.leNumCerca.setPlaceholderText(tipus_seleccionat)
         self.leNumCerca.clear()
         self.leCercaPerAdreca.clear()
         if tipus_seleccionat not in [TipusCerca.ADRECAPOSTAL.value, TipusCerca.CRUILLA.value]:
             self.leNumCerca.hide()
-            self.leCercaPerAdreca.setPlaceholderText(tipus_seleccionat)
+            self.leCercaPerAdreca.setPlaceholderText('')
         else:
             self.leNumCerca.show()
             self.leCercaPerAdreca.setPlaceholderText('Carrer, plaça...')
             if tipus_seleccionat == TipusCerca.CRUILLA.value:
                 self.leNumCerca.setPlaceholderText('Carrer, plaça...')
+            else:
+                self.leNumCerca.setPlaceholderText('Num')
         
 
     def definicioBotons(self):

--- a/qVista.py
+++ b/qVista.py
@@ -1412,7 +1412,7 @@ class QVista(QMainWindow, Ui_MainWindow):
 
         # print(self.tipusCerques)
 
-        self.cAdrecSup=QCercadorAdreca(self.leCercaPerAdreca, self.project, 'SQLITE', self.leNumCerca, self.comboTipusCerca)    # SQLITE o CSV
+        self.cAdrecSup=QCercadorAdreca(self.leCercaPerAdreca, 'SQLITE', self.leNumCerca, self.project, self.comboTipusCerca)    # SQLITE o CSV
         self.bCercaPerAdreca.clicked.connect(lambda: self.leCercaPerAdreca.setText(''))
         self.bCercaPerAdreca.clicked.connect(self.leCercaPerAdreca.setFocus)
         self.bCercaPerAdreca.setCursor(QvConstants.cursorClick())

--- a/qVista.py
+++ b/qVista.py
@@ -431,11 +431,11 @@ class QVista(QMainWindow, Ui_MainWindow):
         
         if self.cAdrec:
             self.cAdrec.set_projecte(self.project)
-            self.cAdrec.carregarTipusCerques()
+            self.cAdrec.carregar_tipus_cerques()
         
         if self.cAdrecSup:
             self.cAdrecSup.set_projecte(self.project)
-            self.cAdrecSup.carregarTipusCerques()
+            self.cAdrecSup.carregar_tipus_cerques()
 
         # if entorn == "'MarxesExploratories'":
         #     self.marxesCiutat()

--- a/qVista.py
+++ b/qVista.py
@@ -88,7 +88,6 @@ from moduls.QvVisorHTML import QvVisorHTML
 from moduls.QvVisualitzacioCapa import QvVisualitzacioCapa
 from moduls.constants import Resultat,TipusCerca
 
-# PREFIX_SEARCH = 'qV_search'
 
 # Impressió del temps de carrega dels moduls Qv
 print ('Temps de carrega dels moduls Qv:', time.time()-iniciTempsModuls)
@@ -437,7 +436,6 @@ class QVista(QMainWindow, Ui_MainWindow):
         if self.cAdrecSup:
             self.cAdrecSup.set_projecte(self.project)
             self.cAdrecSup.carregarTipusCerques()
-        # self.carregarTipusCerques()
 
         # if entorn == "'MarxesExploratories'":
         #     self.marxesCiutat()
@@ -1409,8 +1407,6 @@ class QVista(QMainWindow, Ui_MainWindow):
         self.leNumCerca.setFixedWidth(320)
         self.canviarInfoCerca()
         self.comboTipusCerca.currentIndexChanged.connect(self.canviarInfoCerca)
-
-        # print(self.tipusCerques)
 
         self.cAdrecSup=QCercadorAdreca(self.leCercaPerAdreca, 'SQLITE', self.leNumCerca, self.project, self.comboTipusCerca)    # SQLITE o CSV
         self.bCercaPerAdreca.clicked.connect(lambda: self.leCercaPerAdreca.setText(''))

--- a/qVista.py
+++ b/qVista.py
@@ -1025,17 +1025,15 @@ class QVista(QMainWindow, Ui_MainWindow):
             cercador (Cercador): Objecte que conté la geometria.
         """
         extensio = cercador.coordAdreca.boundingBox()
-        buffer = 0.25  # percentatge d'espai addicional
+        buffer = 0.25 
         x_min = extensio.xMinimum() - (extensio.width() * buffer)
         x_max = extensio.xMaximum() + (extensio.width() * buffer)
         y_min = extensio.yMinimum() - (extensio.height() * buffer)
         y_max = extensio.yMaximum() + (extensio.height() * buffer)
 
-        # Establir l'extensió amb el buffer
         nova_extensio = QgsRectangle(x_min, y_min, x_max, y_max)
         self.canvas.setExtent(nova_extensio)
 
-        # Comprovar si l'escala resultant és menor que l'escala mínima desitjada
         escala_actual = self.canvas.scale()
         escala_minima = 1000
         if escala_actual < escala_minima:
@@ -1949,40 +1947,6 @@ class QVista(QMainWindow, Ui_MainWindow):
                         self.menuEines.addAction(act)
         except Exception as e:
             print(e)
-
-
-    # def carregarTipusCerques(self) -> None:
-    
-    #     variableNames = QgsExpressionContextUtils.projectScope(self.project).variableNames()
-
-    #     searchVariables = [name for name in variableNames if name.startswith(PREFIX_SEARCH)]
-    #     searchVariables = sorted(searchVariables)
-
-    #     self.comboTipusCerca.clear()
-
-    #     layerRegex = re.compile(r'layer="([^"]*)"')
-    #     fieldRegex = re.compile(r'field="([^"]*)"')
-    #     descRegex = re.compile(r'desc="([^"]*)"')
-
-    #     for var in searchVariables:
-    #         rawValue = QgsExpressionContextUtils.projectScope(self.project).variable(var)
-            
-    #         layerMatch = layerRegex.search(rawValue)
-    #         fieldMatch = fieldRegex.search(rawValue)
-    #         descMatch = descRegex.search(rawValue)
-            
-    #         if layerMatch and fieldMatch and descMatch:
-    #             values_dict = {
-    #                 'layer': layerMatch.group(1),
-    #                 'field': fieldMatch.group(1),
-    #                 'desc': descMatch.group(1)
-    #             }
-    #             self.tipusCerques.append(values_dict)
-
-    #             descValue = descMatch.group(1)
-    #             self.comboTipusCerca.addItem(descValue)
-
-        # print(tipusCerques)
 
     def obreEina(self,eina):
         dockWidgets = self.findChildren(eina)


### PR DESCRIPTION
# Canvis fets
- Afegir la possiblitat de definir filtres de cerca per projecte
 - Afegir la possiblitat de definir filtres de cerca per capa

# Configuracio dels filtres
- En els projectes afegir una variable de projecte que començi per `qV_search` i que tingui el seguent format layer="<capa a cercar>" field="<cap a buscar>" desc="<descripcio de la cerca>"
 - En les capes afegir una variable de projecte que començi per `qV_search` i que tingui el seguent format layer="<capa a cercar>" field="<cap a buscar>" desc="<descripcio de la cerca>"